### PR TITLE
Use correct field separator in keywords.txt

### DIFF
--- a/keywords.txt
+++ b/keywords.txt
@@ -8,13 +8,13 @@ Arduino library for IoT-Resort platform
 ###########################################
 
 Thing	KEYWORD1
-IoT-Resort KEYWORD1
+IoT-Resort	KEYWORD1
 
 ###########################################
 # Methods and Functions (KEYWORD2)
 ###########################################
 
 
-SetIoTValue KEYWORD2
-GetIoTControlParameter KEYWORD2
+SetIoTValue	KEYWORD2
+GetIoTControlParameter	KEYWORD2
 


### PR DESCRIPTION
The Arduino IDE requires the use of a single true tab separator between the keyword name and identifier. When spaces are used rather than a true tab the keyword is not highlighted.

Reference:
https://github.com/arduino/Arduino/wiki/Arduino-IDE-1.5:-Library-specification#keywords